### PR TITLE
fix(narugo): fix empty file downloading

### DIFF
--- a/hfutils/index/fetch.py
+++ b/hfutils/index/fetch.py
@@ -240,6 +240,7 @@ def hf_tar_file_download(repo_id: str, archive_in_repo: str, file_in_archive: st
                                 f'in {repo_type}s/{repo_id}@{revision}/{archive_in_repo}.')
 
     info = files[_n_path(file_in_archive)]
+
     url_to_download = hf_hub_url(repo_id, archive_in_repo, repo_type=repo_type, revision=revision, endpoint=endpoint)
     headers = build_hf_headers(
         token=hf_token,
@@ -256,15 +257,16 @@ def hf_tar_file_download(repo_id: str, archive_in_repo: str, file_in_archive: st
         os.makedirs(os.path.dirname(local_file), exist_ok=True)
     try:
         with open(local_file, 'wb') as f:
-            http_get(
-                url_to_download,
-                f,
-                proxies=proxies,
-                resume_size=0,
-                headers=headers,
-                expected_size=info['size'],
-                displayed_filename=file_in_archive,
-            )
+            if info['size'] > 0:
+                http_get(
+                    url_to_download,
+                    f,
+                    proxies=proxies,
+                    resume_size=0,
+                    headers=headers,
+                    expected_size=info['size'],
+                    displayed_filename=file_in_archive,
+                )
 
         if os.path.getsize(local_file) != info['size']:
             raise ArchiveStandaloneFileIncompleteDownload(

--- a/test/index/test_fetch.py
+++ b/test/index/test_fetch.py
@@ -1,3 +1,5 @@
+import os.path
+
 import pytest
 from hbutils.testing import isolated_directory
 from natsort import natsorted
@@ -81,3 +83,14 @@ class TestIndexFetch:
                 local_file='f/ac.jpg'
             )
             file_compare(get_testfile('sankaku_21305298.jpg'), 'f/ac.jpg')
+
+    def test_hf_tar_file_download_empty(self):
+        with isolated_directory():
+            hf_tar_file_download(
+                repo_id='nyanko7/danbooru2023',
+                idx_repo_id='deepghs/danbooru2023_index',
+                archive_in_repo='original/data-0001.tar',
+                file_in_archive='2946001.',
+                local_file='2946001.',
+            )
+            assert os.path.getsize('2946001.') == 0


### PR DESCRIPTION
```python
import os

from hfutils.index import hf_tar_file_download

hf_tar_file_download(
    repo_id='nyanko7/danbooru2023',
    idx_repo_id='deepghs/danbooru2023_index',
    archive_in_repo='original/data-0001.tar',
    file_in_archive='2946001.',
    local_file='2946001.',
)
assert os.path.getsize('2946001.') == 0
```