### PR TITLE
dev(narugo): add url functions for repo path or file

### DIFF
--- a/docs/source/api_doc/repository/index.rst
+++ b/docs/source/api_doc/repository/index.rst
@@ -12,4 +12,5 @@ hfutils.repository
     base
     clone
     rollback
+    url
 

--- a/docs/source/api_doc/repository/url.rst
+++ b/docs/source/api_doc/repository/url.rst
@@ -1,0 +1,23 @@
+hfutils.repository.url
+=============================================
+
+.. currentmodule:: hfutils.repository.url
+
+.. automodule:: hfutils.repository.url
+
+
+
+hf_hub_repo_path_url
+----------------------------------------------------
+
+.. autofunction:: hf_hub_repo_path_url
+
+
+
+hf_hub_repo_file_url
+----------------------------------------------------
+
+.. autofunction:: hf_hub_repo_file_url
+
+
+

--- a/hfutils/repository/__init__.py
+++ b/hfutils/repository/__init__.py
@@ -5,3 +5,4 @@ Overview:
 from .base import hf_hub_repo_url
 from .clone import hf_hub_clone
 from .rollback import hf_hub_rollback
+from .url import hf_hub_repo_path_url, hf_hub_repo_file_url

--- a/hfutils/repository/url.py
+++ b/hfutils/repository/url.py
@@ -1,0 +1,29 @@
+from typing import Optional
+from urllib.parse import quote_plus, urljoin
+
+from .base import hf_hub_repo_url
+from ..utils.path import RepoTypeTyping, hf_normpath
+
+
+def hf_hub_repo_path_url(repo_id: str, path: str, repo_type: RepoTypeTyping = 'dataset',
+                         revision: str = 'main', endpoint: Optional[str] = None) -> str:
+    # url of the huggingface repository path
+    repo_url = hf_hub_repo_url(
+        repo_id=repo_id,
+        repo_type=repo_type,
+        endpoint=endpoint,
+    )
+    return urljoin(repo_url + '/', hf_normpath(f'tree/{quote_plus(revision)}/{hf_normpath(path)}'))
+
+
+def hf_hub_repo_file_url(repo_id: str, path: str, repo_type: RepoTypeTyping = 'dataset',
+                         revision: str = 'main', endpoint: Optional[str] = None) -> str:
+    # url of the huggingface repository file
+    # note: this is not the downloadable url of the file in repository,
+    #       if you're looking for url for downloading, use :func:`huggingface_hub.hf_hub_url`.
+    repo_url = hf_hub_repo_url(
+        repo_id=repo_id,
+        repo_type=repo_type,
+        endpoint=endpoint,
+    )
+    return urljoin(repo_url + '/', hf_normpath(f'blob/{quote_plus(revision)}/{hf_normpath(path)}'))

--- a/hfutils/repository/url.py
+++ b/hfutils/repository/url.py
@@ -1,3 +1,10 @@
+"""
+This module provides functions for generating URLs related to Hugging Face Hub repositories.
+
+It includes functions to create URLs for repository paths and files, which can be useful
+for accessing and referencing resources within Hugging Face Hub repositories.
+"""
+
 from typing import Optional
 from urllib.parse import quote_plus, urljoin
 
@@ -7,7 +14,31 @@ from ..utils.path import RepoTypeTyping, hf_normpath
 
 def hf_hub_repo_path_url(repo_id: str, path: str, repo_type: RepoTypeTyping = 'dataset',
                          revision: str = 'main', endpoint: Optional[str] = None) -> str:
-    # url of the huggingface repository path
+    """
+    Generate the URL for a path within a Hugging Face Hub repository.
+
+    This function constructs a URL that points to a specific path within a Hugging Face Hub repository.
+    It's useful for creating links to directories or files in the repository's web interface.
+
+    :param repo_id: The repository ID (e.g., 'username/repo-name').
+    :type repo_id: str
+    :param path: The path within the repository to generate the URL for.
+    :type path: str
+    :param repo_type: The type of the repository. Defaults to 'dataset'.
+    :type repo_type: RepoTypeTyping, optional
+    :param revision: The revision (branch, tag, or commit) to use. Defaults to 'main'.
+    :type revision: str, optional
+    :param endpoint: The API endpoint to use. If None, the default endpoint will be used.
+    :type endpoint: str, optional
+
+    :return: The URL for the specified path in the Hugging Face Hub repository.
+    :rtype: str
+
+    :example:
+        >>> url = hf_hub_repo_path_url('username/my-dataset', 'data/train.csv')
+        >>> print(url)
+        https://huggingface.co/datasets/username/my-dataset/tree/main/data/train.csv
+    """
     repo_url = hf_hub_repo_url(
         repo_id=repo_id,
         repo_type=repo_type,
@@ -18,9 +49,35 @@ def hf_hub_repo_path_url(repo_id: str, path: str, repo_type: RepoTypeTyping = 'd
 
 def hf_hub_repo_file_url(repo_id: str, path: str, repo_type: RepoTypeTyping = 'dataset',
                          revision: str = 'main', endpoint: Optional[str] = None) -> str:
-    # url of the huggingface repository file
-    # note: this is not the downloadable url of the file in repository,
-    #       if you're looking for url for downloading, use :func:`huggingface_hub.hf_hub_url`.
+    """
+    Generate the URL for a file within a Hugging Face Hub repository.
+
+    This function constructs a URL that points to a specific file within a Hugging Face Hub repository.
+    It's useful for creating links to view files in the repository's web interface.
+
+    :param repo_id: The repository ID (e.g., 'username/repo-name').
+    :type repo_id: str
+    :param path: The path to the file within the repository.
+    :type path: str
+    :param repo_type: The type of the repository. Defaults to 'dataset'.
+    :type repo_type: RepoTypeTyping, optional
+    :param revision: The revision (branch, tag, or commit) to use. Defaults to 'main'.
+    :type revision: str, optional
+    :param endpoint: The API endpoint to use. If None, the default endpoint will be used.
+    :type endpoint: str, optional
+
+    :return: The URL for the specified file in the Hugging Face Hub repository.
+    :rtype: str
+
+    :example:
+        >>> url = hf_hub_repo_file_url('username/my-model', 'config.json')
+        >>> print(url)
+        https://huggingface.co/username/my-model/blob/main/config.json
+
+    .. note::
+        This is not the downloadable URL of the file in the repository.
+        For downloading URLs, use :func:`huggingface_hub.hf_hub_url`.
+    """
     repo_url = hf_hub_repo_url(
         repo_id=repo_id,
         repo_type=repo_type,

--- a/test/repository/test_url.py
+++ b/test/repository/test_url.py
@@ -1,0 +1,55 @@
+from unittest.mock import patch
+
+import pytest
+
+from hfutils.repository import hf_hub_repo_path_url, hf_hub_repo_file_url
+
+
+# Fixtures
+@pytest.fixture
+def mock_hf_hub_repo_url():
+    with patch('hfutils.repository.url.hf_hub_repo_url') as mock:
+        mock.return_value = 'https://huggingface.co/repo'
+        yield mock
+
+
+@pytest.fixture
+def mock_hf_normpath():
+    with patch('hfutils.repository.url.hf_normpath') as mock:
+        mock.side_effect = lambda x: x
+        yield mock
+
+
+@pytest.mark.unittest
+class TestHuggingFaceHubUrls:
+    def test_hf_hub_repo_path_url_default(self, mock_hf_hub_repo_url, mock_hf_normpath):
+        result = hf_hub_repo_path_url('user/repo', 'path/to/file')
+        assert result == 'https://huggingface.co/repo/tree/main/path/to/file'
+        mock_hf_hub_repo_url.assert_called_once_with(repo_id='user/repo', repo_type='dataset', endpoint=None)
+
+    def test_hf_hub_repo_path_url_custom(self, mock_hf_hub_repo_url, mock_hf_normpath):
+        result = hf_hub_repo_path_url('user/repo', 'path/to/file', repo_type='model', revision='dev',
+                                      endpoint='https://custom.com')
+        assert result == 'https://huggingface.co/repo/tree/dev/path/to/file'
+        mock_hf_hub_repo_url.assert_called_once_with(repo_id='user/repo', repo_type='model',
+                                                     endpoint='https://custom.com')
+
+    def test_hf_hub_repo_path_url_special_chars(self, mock_hf_hub_repo_url, mock_hf_normpath):
+        result = hf_hub_repo_path_url('user/repo', 'path/to/file with spaces', revision='branch/with/slashes')
+        assert result == 'https://huggingface.co/repo/tree/branch%2Fwith%2Fslashes/path/to/file with spaces'
+
+    def test_hf_hub_repo_file_url_default(self, mock_hf_hub_repo_url, mock_hf_normpath):
+        result = hf_hub_repo_file_url('user/repo', 'path/to/file')
+        assert result == 'https://huggingface.co/repo/blob/main/path/to/file'
+        mock_hf_hub_repo_url.assert_called_once_with(repo_id='user/repo', repo_type='dataset', endpoint=None)
+
+    def test_hf_hub_repo_file_url_custom(self, mock_hf_hub_repo_url, mock_hf_normpath):
+        result = hf_hub_repo_file_url('user/repo', 'path/to/file', repo_type='model', revision='dev',
+                                      endpoint='https://custom.com')
+        assert result == 'https://huggingface.co/repo/blob/dev/path/to/file'
+        mock_hf_hub_repo_url.assert_called_once_with(repo_id='user/repo', repo_type='model',
+                                                     endpoint='https://custom.com')
+
+    def test_hf_hub_repo_file_url_special_chars(self, mock_hf_hub_repo_url, mock_hf_normpath):
+        result = hf_hub_repo_file_url('user/repo', 'path/to/file with spaces', revision='branch/with/slashes')
+        assert result == 'https://huggingface.co/repo/blob/branch%2Fwith%2Fslashes/path/to/file with spaces'

--- a/test/repository/test_url.py
+++ b/test/repository/test_url.py
@@ -53,3 +53,53 @@ class TestHuggingFaceHubUrls:
     def test_hf_hub_repo_file_url_special_chars(self, mock_hf_hub_repo_url, mock_hf_normpath):
         result = hf_hub_repo_file_url('user/repo', 'path/to/file with spaces', revision='branch/with/slashes')
         assert result == 'https://huggingface.co/repo/blob/branch%2Fwith%2Fslashes/path/to/file with spaces'
+
+    def test_hf_hub_repo_path_url_default_x(self):
+        result = hf_hub_repo_path_url('user/repo', 'path/to/file')
+        expected = f"https://huggingface.co/datasets/user/repo/tree/main/path/to/file"
+        assert result == expected
+
+    def test_hf_hub_repo_path_url_model(self):
+        result = hf_hub_repo_path_url('user/repo', 'path/to/file', repo_type='model')
+        expected = f"https://huggingface.co/user/repo/tree/main/path/to/file"
+        assert result == expected
+
+    def test_hf_hub_repo_path_url_space(self):
+        result = hf_hub_repo_path_url('user/repo', 'path/to/file', repo_type='space')
+        expected = f"https://huggingface.co/spaces/user/repo/tree/main/path/to/file"
+        assert result == expected
+
+    def test_hf_hub_repo_path_url_custom_revision(self):
+        result = hf_hub_repo_path_url('user/repo', 'path/to/file', revision='v1.0')
+        expected = f"https://huggingface.co/datasets/user/repo/tree/v1.0/path/to/file"
+        assert result == expected
+
+    def test_hf_hub_repo_path_url_custom_endpoint(self):
+        result = hf_hub_repo_path_url('user/repo', 'path/to/file', endpoint='https://custom.com')
+        expected = f"https://custom.com/datasets/user/repo/tree/main/path/to/file"
+        assert result == expected
+
+    def test_hf_hub_repo_file_url_default(self):
+        result = hf_hub_repo_file_url('user/repo', 'path/to/file')
+        expected = f"https://huggingface.co/datasets/user/repo/blob/main/path/to/file"
+        assert result == expected
+
+    def test_hf_hub_repo_file_url_model(self):
+        result = hf_hub_repo_file_url('user/repo', 'path/to/file', repo_type='model')
+        expected = f"https://huggingface.co/user/repo/blob/main/path/to/file"
+        assert result == expected
+
+    def test_hf_hub_repo_file_url_space(self):
+        result = hf_hub_repo_file_url('user/repo', 'path/to/file', repo_type='space')
+        expected = f"https://huggingface.co/spaces/user/repo/blob/main/path/to/file"
+        assert result == expected
+
+    def test_hf_hub_repo_file_url_custom_revision(self):
+        result = hf_hub_repo_file_url('user/repo', 'path/to/file', revision='v1.0')
+        expected = f"https://huggingface.co/datasets/user/repo/blob/v1.0/path/to/file"
+        assert result == expected
+
+    def test_hf_hub_repo_file_url_custom_endpoint(self):
+        result = hf_hub_repo_file_url('user/repo', 'path/to/file', endpoint='https://custom.com')
+        expected = f"https://custom.com/datasets/user/repo/blob/main/path/to/file"
+        assert result == expected


### PR DESCRIPTION
```python
from hfutils.repository import hf_hub_repo_path_url, hf_hub_repo_file_url

print(hf_hub_repo_path_url(
    repo_id='deepghs/character_index',
    path='default',
    revision='refs/convert/duckdb'
))

print(hf_hub_repo_file_url(
    repo_id='deepghs/character_index',
    path='00/asagumo_kancolle/1.webp',
    # revision='refs/convert/duckdb'
))
```